### PR TITLE
Output project/task contact email links as HTML

### DIFF
--- a/dotproject/modules/tasks/view.php
+++ b/dotproject/modules/tasks/view.php
@@ -398,7 +398,7 @@ function delIt() {
 			    			foreach ($contacts as $contact_id => $contact_data) {
 			    				echo '<tr>';
 			    				echo '<td class="hilite"><a href="index.php?m=contacts&a=addedit&contact_id=' . $contact_id . '">' . $AppUI->___($contact_data['contact_first_name'].' '.$contact_data['contact_last_name']) .'</a></td>';
-			    				echo '<td class="hilite">' . $AppUI->___('<a href="mailto: '.$contact_data['contact_email'].'">'.$contact_data['contact_email'].'</a>') . '</td>';
+			    				echo '<td class="hilite">' . $AppUI->showHTML('<a href="mailto: '.$contact_data['contact_email'].'">'.$contact_data['contact_email'].'</a>') . '</td>';
 			    				echo '<td class="hilite">'.$AppUI->___($contact_data['contact_phone']).'</td>';
 			    				echo '<td class="hilite">'.$AppUI->___($contact_data['dept_name']).'</td>';
 			    				echo '</tr>';
@@ -434,7 +434,7 @@ function delIt() {
 			    			foreach ($contacts as $contact_id => $contact_data) {
 			    				echo '<tr>';
 			    				echo '<td class="hilite"><a href="index.php?m=contacts&a=addedit&contact_id=' . $contact_id . '">' . $AppUI->___($contact_data['contact_first_name'].' '.$contact_data['contact_last_name']).'</a></td>';
-			    				echo '<td class="hilite">' . $AppUI->___('<a href="mailto: '.$contact_data['contact_email'].'">'.$contact_data['contact_email'].'</a>') . '</td>';
+			    				echo '<td class="hilite">' . $AppUI->showHTML('<a href="mailto: '.$contact_data['contact_email'].'">'.$contact_data['contact_email'].'</a>') . '</td>';
 			    				echo '<td class="hilite">'.$AppUI->___($contact_data['contact_phone']).'</td>';
 			    				echo '<td class="hilite">'.$AppUI->___($contact_data['dept_name']).'</td>';
 			    				echo '</tr>';


### PR DESCRIPTION
The `mailto` HTML contact links for tasks are rendering as plaintext html. 

![screenshot from 2017-11-16 16-19-22](https://user-images.githubusercontent.com/6703966/32875091-35743cbc-caea-11e7-9494-29041151cf36.png)

We're calling it with the default functionality of `$AppUI->___` (https://github.com/dotproject/dotProject/blob/master/dotproject/classes/ui.class.php#L446).  I'm proposing we call it with `$AppUI->showHTML`. Which changes the UI to:

![screenshot from 2017-11-16 16-17-13](https://user-images.githubusercontent.com/6703966/32875118-4e9c84f6-caea-11e7-8957-99ac7f1bfe6c.png)