### PR TITLE
update php instantiation syntax for projectdesigner 

### DIFF
--- a/modules/projectdesigner/gantt.php
+++ b/modules/projectdesigner/gantt.php
@@ -17,7 +17,7 @@ $f = defVal( @$_REQUEST['f'], 0 );
 $df = $AppUI->getPref('SHDATEFORMAT');
 
 require_once $AppUI->getModuleClass('projects');
-$project =& new CProject;
+$project = new CProject();
 $criticalTasks = ($project_id > 0) ? $project->getCriticalTasks($project_id) : NULL;
 $criticalTasksInverted = ($project_id > 0) ? getCriticalTasksInverted($project_id) : NULL;
 
@@ -114,7 +114,7 @@ if ($caller == 'todo') {
 }
 
 // get any specifically denied tasks
-$task =& new CTask;
+$task = new CTask();
 $task->setAllowedSQL($AppUI->user_id, $q);
 
 $proTasks = $q->loadHashList('task_id');

--- a/modules/projectdesigner/vw_actions.php
+++ b/modules/projectdesigner/vw_actions.php
@@ -28,7 +28,7 @@ $sowners = array(''=>'(Task Owner)') + $users;
 $sassign = array(''=>'(Assign User)') + $users;
 $sunassign = array(''=>'(Unassign User)') + $users;
 
-$obj =& new CTask;
+$obj = new CTask();
 $allowedTasks = $obj->getAllowedSQL($AppUI->user_id, 't.task_id');
 
 $obj->load($task_id);

--- a/modules/projectdesigner/vw_projecttask.php
+++ b/modules/projectdesigner/vw_projecttask.php
@@ -140,7 +140,7 @@ if (isset($_POST['show_task_options'])) {
 }
 $showIncomplete = $AppUI->getState('TaskListShowIncomplete', 0);
 
-$project =& new CProject;
+$project = new CProject();
 // $allowedProjects = $project->getAllowedRecords($AppUI->user_id, 'project_id, project_name');
 $allowedProjects = $project->getAllowedSQL($AppUI->user_id);
 $working_hours = ($dPconfig['daily_working_hours']?$dPconfig['daily_working_hours']:8);
@@ -228,7 +228,7 @@ $allowedProjects = $project->getAllowedSQL($AppUI->user_id, 'task_project');
 if (count($allowedProjects)) {
 	$q->addWhere($allowedProjects);
 }
-$obj =& new CTask;
+$obj = new CTask();
 $allowedTasks = $obj->getAllowedSQL($AppUI->user_id, 't.task_id');
 if ( count($allowedTasks)) {
 	$q->addWhere($allowedTasks);

--- a/modules/projectdesigner/vw_tasks.php
+++ b/modules/projectdesigner/vw_tasks.php
@@ -109,7 +109,7 @@ if (isset($_POST['show_task_options'])) {
 }
 $showIncomplete = $AppUI->getState('TaskListShowIncomplete', 0);
 
-$project =& new CProject;
+$project = new CProject();
 // $allowedProjects = $project->getAllowedRecords($AppUI->user_id, 'project_id, project_name');
 $allowedProjects = $project->getAllowedSQL($AppUI->user_id);
 $working_hours = ($dPconfig['daily_working_hours']?$dPconfig['daily_working_hours']:8);
@@ -197,7 +197,7 @@ $allowedProjects = $project->getAllowedSQL($AppUI->user_id, 'task_project');
 if (count($allowedProjects)) {
 	$q->addWhere($allowedProjects);
 }
-$obj =& new CTask;
+$obj = new CTask();
 $allowedTasks = $obj->getAllowedSQL($AppUI->user_id, 't.task_id');
 if ( count($allowedTasks)) {
 	$q->addWhere($allowedTasks);


### PR DESCRIPTION
Hi Adam, 
I hit another issue in this upgrade with the project designer module having deprecated php syntax, and throwing errors

`Parse error: syntax error, unexpected 'new' (T_NEW) in /data/srv/debortoli.private/dotProject.git/modules/projectdesigner/vw_tasks.php on line 112
`
patch attached, covering all deprecated `=& new` syntax in the pd module