### PR TITLE
more fixes for old-style assign by reference in projectdesigner

### DIFF
--- a/modules/projectdesigner/vw_projecttask.php
+++ b/modules/projectdesigner/vw_projecttask.php
@@ -140,7 +140,7 @@ if (isset($_POST['show_task_options'])) {
 }
 $showIncomplete = $AppUI->getState('TaskListShowIncomplete', 0);
 
-$project =& new CProject;
+$project = new CProject;
 // $allowedProjects = $project->getAllowedRecords($AppUI->user_id, 'project_id, project_name');
 $allowedProjects = $project->getAllowedSQL($AppUI->user_id);
 $working_hours = ($dPconfig['daily_working_hours']?$dPconfig['daily_working_hours']:8);
@@ -228,7 +228,7 @@ $allowedProjects = $project->getAllowedSQL($AppUI->user_id, 'task_project');
 if (count($allowedProjects)) {
 	$q->addWhere($allowedProjects);
 }
-$obj =& new CTask;
+$obj = new CTask;
 $allowedTasks = $obj->getAllowedSQL($AppUI->user_id, 't.task_id');
 if ( count($allowedTasks)) {
 	$q->addWhere($allowedTasks);


### PR DESCRIPTION
Hi Adam, 
I hit another issue in this upgrade with the project designer module having deprecated php syntax, and throwing errors

`Parse error: syntax error, unexpected 'new' (T_NEW) in /data/srv/debortoli.private/dotProject.git/modules/projectdesigner/vw_tasks.php on line 112
`
It looks like that's been partially patched in devel ref #37, I found another couple of instances