### PR TITLE
Optimise query for editing tasks

### DIFF
--- a/modules/tasks/tasks.class.php
+++ b/modules/tasks/tasks.class.php
@@ -1772,7 +1772,6 @@ class CTask extends CDpObject
 		if (!dPgetConfig('direct_edit_assignment')) {
 			return array();
 		}
-		
 		$hash_key = $hash ? $hash : '<NONE>';
 		$user_key = $users ? implode(',', $users) : '<NONE>';
 
@@ -1790,29 +1789,37 @@ class CTask extends CDpObject
 				 * provide actual assignment charge, individual chargeMax 
 				 * and freeCapacity of users' assignments to tasks
 				*/
-				$q = new DBQuery;
+				$subqC = new DBQuery;
+				$subqUT = new DBQuery;
 				$q->addTable('users', 'u');
-				$q->leftJoin('contacts', 'c', 'c.contact_id = u.user_contact');
-				$q->leftJoin('user_tasks', 'ut', 'ut.user_id = u.user_id');
-				$q->leftJoin('user_preferences', 'up', "up.pref_user = u.user_id AND up.pref_name = 'TASKASSIGNMAX'");
-				$q->addQuery("u.user_id, CONCAT(CONCAT_WS(' [', CONCAT_WS(' '" 
-							 . ', contact_first_name, contact_last_name), IF(IFNULL((IFNULL(up.pref_value' 
-							 . ', ' . $scm . ') - SUM(ut.perc_assignment)), up.pref_value) > 0' 
-							 . ', IFNULL((IFNULL(up.pref_value, ' . $scm . ') - SUM(ut.perc_assignment))' 
-							 . ', up.pref_value), 0)), ' . "'%]')" . ' AS userFC' 
-							 . ', IFNULL(SUM(ut.perc_assignment), 0) AS charge, u.user_username' 
-							 . ', IFNULL(up.pref_value,' . $scm . ') AS chargeMax' 
-							 . ', IF(IFNULL((IFNULL(up.pref_value, ' . $scm . ') ' 
-							 . '- SUM(ut.perc_assignment)), up.pref_value) > 0' 
-							 . ', IFNULL((IFNULL(up.pref_value, ' . $scm . ') - SUM(ut.perc_assignment))' 
-							 . ', up.pref_value), 0) AS freeCapacity');
-				if (!empty($users)) { // use userlist if available otherwise pull data for all users
-					$q->addWhere('u.user_id IN (' . implode(',', $users) . ')');
-				}
+				$q->addQuery("u.user_id, CONCAT(CONCAT_WS(' [', CONCAT_WS(' '"
+							. ', contact_first_name, contact_last_name), IF(IFNULL((IFNULL(up.pref_value'
+							. ', ' . $scm . ') - SUM(ut.perc_assignment)), up.pref_value) > 0'
+							. ', IFNULL((IFNULL(up.pref_value, ' . $scm . ') - SUM(ut.perc_assignment))'
+							. ', up.pref_value), 0)), ' . "'%]')" . ' AS userFC'
+							. ', IFNULL(SUM(ut.perc_assignment), 0) AS charge, u.user_username'
+							. ', IFNULL(up.pref_value,' . $scm . ') AS chargeMax'
+							. ', IF(IFNULL((IFNULL(up.pref_value, ' . $scm . ') '
+							. '- SUM(ut.perc_assignment)), up.pref_value) > 0'
+							. ', IFNULL((IFNULL(up.pref_value, ' . $scm . ') - SUM(ut.perc_assignment))'
+							. ', up.pref_value), 0) AS freeCapacity');
+				// Sub-query for contacts table
+				$subqC->addTable('contacts');
+				$subqC->addGroup('contact_id');
+				// Sub-query for user_tasks table
+				$subqUT->addTable('user_tasks');
+				$subqUT->addQuery("user_id, user_type, task_id, SUM(perc_assignment) AS 'perc_assignment', user_task_priority");
+				$subqUT->addGroup('user_id');
+
+				$q->leftJoin($subqC, 'c', 'c.contact_id = u.user_contact');
+				$q->leftJoin($subqUT, 'ut', 'ut.user_id = u.user_id');
+				$q->leftJoin('user_preferences', 'up', 'up.pref_user = u.user_id');
 				$q->addGroup('u.user_id');
-				$q->addOrder('contact_last_name, contact_first_name');
+				$q->addOrder('contact_last_name, contact_first_name, u.user_id');
 				$sql = $q->prepare();
 				$q->clear();
+				$subqC->clear();
+				$subqUT->clear();
 				//echo "<pre>$sql</pre>";
 				$Allocations[$hash_key][$user_key] = db_loadHashList($sql, $hash);
 			}


### PR DESCRIPTION
Hi @ajdonnison,

I've edited the query that we talked about in #39 and testing it on our test servers gave us sub-second task-edit times as opposed to the 17+ seconds we were previously seeing. Just thought you'd also like to check it out before we put it on our live server.

PS. I tried testing this in the devel branch before submitting this pull request  but there were a lot of issues with it, I'm not sure if you know about it.
![devel-issues](https://user-images.githubusercontent.com/21019692/65216842-90a3b000-daf5-11e9-9d8f-11fbc0f14c29.png)
