### PR TITLE
fix italics for quilljs

### DIFF
--- a/style/default/main.css
+++ b/style/default/main.css
@@ -33,6 +33,11 @@ em {
 	font-style: normal;
 }
 
+.ql-editor em {
+	font-weight: normal;
+	font-style: italic;
+}
+
 A:link {
 	color: #08245b;
 	text-decoration: none;


### PR DESCRIPTION
The italic option in quilljs was making text bold instead of italic due to the HTML em tag being overwritten in css. A simple fix for this was to make an extra rule to make the em tag default for quill.