### PR TITLE
Add config option for archive projects display in all tab

### DIFF
--- a/modules/projects/config.php
+++ b/modules/projects/config.php
@@ -1,0 +1,3 @@
+<?php // Do not write to this file by hand, it will be overwritten by the configuration utility. 
+$PROJECTS_CONFIG['always_show_archived'] = '0';
+?>

--- a/modules/projects/configure.php
+++ b/modules/projects/configure.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * This file will write a php config file to be included during the execution of
+ * all Task files which require the config options.
+ */
+global $m;
+
+// Deny all but system admins
+if (getDenyEdit('system'))
+    $AppUI->redirect("m=public&a=access_denied");
+
+@include_once('./functions/admin_func.php');
+$CONFIG_FILE = './modules/projects/config.php';
+
+$AppUI->savePlace();
+
+// Define user type list
+$user_types = arrayMerge($utypes, array('9' => $AppUI->_('None')));
+
+$config_options = array(
+    'heading1' => $AppUI->_('General Options'),
+    'always_show_archived' => array(
+        'description' => $AppUI->_('Show Archived Projects In All Tab'),
+        'value' => '1',
+        'type' => 'radio',
+    	'buttons' => array (1 => $AppUI->_('Yes'), 0 => $AppUI->_('No'))
+    )
+);
+
+// If this is a submitted page, overwrite the config file
+if (dPgetParam($_POST, 'Save', '') != '') {
+    if (is_writable($CONFIG_FILE)) {
+        if (!$handle = fopen($CONFIG_FILE, 'w')) {
+            $AppUI->setMsg($CONFIG_FILE . ' ' . $AppUI->_('cannot be opened'), UI_MSG_ERROR);
+            exit;
+        }
+
+        if (fwrite($handle, "<?php // Do not write to this file by hand, it will be overwritten by the configuration utility. \n") === FALSE) {
+            $AppUI->setMsg($CONFIG_FILE . ' ' . $AppUI->_('cannot be written to'), UI_MSG_ERROR);
+            exit;
+        } else {
+            foreach ($config_options as $key=>$value) {
+                if (substr($key, 0, 7) == 'heading')
+                    continue;
+
+                $val = '';
+                switch ($value['type']) {
+                    case 'checkbox':
+                        $val = isset($_POST[$key]) ? '1' : '0';
+                        break;
+                    case 'text':
+                        $val = isset($_POST[$key]) ? $_POST[$key] : '';
+                        break;
+                    case 'longtext':
+                        $val = isset($_POST[$key]) ? $_POST[$key] : '';
+                        break;
+                    case 'select':
+                        $val = isset($_POST[$key]) ? $_POST[$key] : '0';
+                        break;
+                    case 'radio':
+                        $val = $_POST[$key];
+                        break;
+                    default:
+                        break;
+                }
+                fwrite($handle, "\$PROJECTS_CONFIG['" . $key . "'] = '" . $val . "';\n");
+            }
+            fwrite($handle, "?>\n");
+            $AppUI->setMsg($CONFIG_FILE . ' ' . $AppUI->_('has been successfully updated'), UI_MSG_OK);
+            require($CONFIG_FILE);
+        }
+    } else {
+        $AppUI->setMsg($CONFIG_FILE . ' ' . $AppUI->_('is not writable'), UI_MSG_ERROR);
+    }
+} elseif (dPgetParam($_POST, $AppUI->_('Cancel'), '') != '') {
+    $AppUI->redirect('m=system&a=viewmods');
+}
+
+include($CONFIG_FILE);
+
+// Read the current config values from config file and update the array
+foreach ($config_options as $key=>$value)
+    if (isset($PROJECTS_CONFIG[$key]))
+        $config_options[$key]['value'] = $PROJECTS_CONFIG[$key];
+
+// Setup the title block
+$titleBlock = new CTitleBlock('Projects Module Configuration', 'applet3-48.png', $m, "$m.$a");
+$titleBlock->addCrumb('?m=system', 'System Admin');
+$titleBlock->addCrumb('?m=system&a=viewmods', 'Modules');
+$titleBlock->show();
+?>
+
+<form method="post">
+    <table class="std">
+    <?php
+    foreach ($config_options as $key=>$value){
+    ?>
+	    <tr>
+		<?php
+        // the key starts with hr, then just display the value
+	    if(substr($key,0,7)=='heading'){ ?>
+		    <th align="center" colspan="2"><?php echo $value?></th>
+		<?php } else { ?>
+		    <td align="right"><?php echo $value['description']?></td>
+		    <td>
+            <?php
+            switch($value['type']){
+                case 'checkbox': ?>
+                    <input type="checkbox" name="<?php echo $key?>" <?php echo $value['value']?"checked=\"checked\"":""?>>
+                    <?php
+                    break;
+                case 'text': ?>
+                    <input type="text" name="<?php echo $key?>" style="<?php echo $value['style']?>" value="<?php echo $value['value']?>">
+                    <?php
+                    break;
+                case 'longtext': ?>
+                    <input type="text" size="70" name="<?php echo $key?>" style="<?php echo $value['style']?>" value="<?php echo $value['value']?>">
+                    <?php
+                    break;
+                case 'select': 
+                    print arraySelect( $value["list"], $key, 'class="text" size="1" id="' . $key . '" ' . $value["events"], $value["value"] );
+                    break;
+                case 'radio':
+                    foreach ($value['buttons'] as $v => $n) { ?>
+                        <label>
+                            <input type="radio" name="<?php echo $key; ?>" id="<?php echo $key; ?>" value=<?php echo $v; ?> <?php echo (($value['value'] == $v)?"checked":""); ?> <?php echo $value['events']; ?>> <?php echo $n;?>
+                        </label>
+                    <?php }
+                    break;
+                default:
+                    break;
+            } ?>
+            </td>
+		<?php
+		}
+		?>
+	    </tr>
+    <?php	
+    }
+    ?>
+	<tr>
+		<td colspan="2" align="right"><input type="Submit" name="Cancel" value="<?php echo $AppUI->_('back')?>">
+            <input type="Submit" name="Save" value="<?php echo $AppUI->_('save')?>">
+        </td>
+	</tr>
+</table>
+</form>

--- a/modules/projects/index.php
+++ b/modules/projects/index.php
@@ -3,7 +3,7 @@ if (!defined('DP_BASE_DIR')) {
 	die('You should not access this file directly.');
 }
 
-global $cBuffer;
+global $cBuffer, $PROJECTS_CONFIG;
 
 $AppUI->savePlace();
 $q = new DBQuery();
@@ -156,6 +156,9 @@ $project_types = dPgetSysVal('ProjectStatus');
 // count number of projects per project_status
 $q->addTable('projects', 'p');
 $q->addQuery('p.project_status, COUNT(p.project_id) as count');
+if ($PROJECTS_CONFIG['always_show_archived'] == 0) {
+	$q->addWhere('NOT p.project_status=7');
+}
 $obj_project->setAllowedSQL($AppUI->user_id, $q, null, 'p');
 if ($owner > 0) {
 	$q->addWhere('p.project_owner = ' . $owner);

--- a/modules/projects/projects.class.php
+++ b/modules/projects/projects.class.php
@@ -14,6 +14,7 @@ require_once ($AppUI->getSystemClass('date'));
 require_once ($AppUI->getModuleClass('tasks'));
 require_once ($AppUI->getModuleClass('companies'));
 require_once ($AppUI->getModuleClass('departments'));
+include_once("./modules/projects/config.php");
 
 /**
  * The Project Class

--- a/modules/projects/setup.php
+++ b/modules/projects/setup.php
@@ -1,0 +1,21 @@
+<?php
+// MODULE CONFIGURATION DEFINITION
+$config = array();
+$config['mod_name'] = 'Projects';
+$config['mod_version'] = '1.0.0';
+$config['mod_directory'] = 'projects';
+$config['mod_setup_class'] = 'Projects';
+$config['mod_type'] = 'user';
+$config['mod_ui_name'] = 'Projects';
+$config['mod_ui_icon'] = 'applet3-48.png';
+$config['mod_description'] = 'A module for Project management';
+$config['mod_config'] = true;
+if (@$a == 'setup')
+    echo dPshowModuleConfig($config);
+class Projects {
+    function configure() {
+        global $AppUI;
+        $AppUI->redirect('m=projects&a=configure');
+        return true;
+    }
+}

--- a/modules/projects/view.php
+++ b/modules/projects/view.php
@@ -15,7 +15,7 @@ $canEdit = getPermission($m, 'edit', $project_id);
 
 $canAuthorTask = getPermission('tasks', 'add');
 
-//Check if the proect is viewable.
+//Check if the project is viewable.
 if (!($canRead)) {
 	$AppUI->redirect('m=public&a=access_denied');
 }

--- a/modules/projects/vw_idx_proposed.php
+++ b/modules/projects/vw_idx_proposed.php
@@ -4,7 +4,7 @@ if (!defined('DP_BASE_DIR')) {
 }
 
 GLOBAL $AppUI, $projects, $company_id, $pstatus, $project_types, $currentTabId, $currentTabName;
-GLOBAL $priority;
+GLOBAL $priority, $PROJECTS_CONFIG;
 
 $show_all_projects = false;
 if ($currentTabId == 500) {
@@ -115,6 +115,9 @@ $project_status_filter = $currentTabId;
 
 foreach ($projects as $row) {
 	if (! getPermission('projects', 'view', $row['project_id'])) {
+		continue;
+	}
+	if ($show_all_projects && $PROJECTS_CONFIG['always_show_archived'] == 0 && $row['project_status'] == 7) {
 		continue;
 	}
 	if ($show_all_projects || $row['project_status'] == $project_status_filter) {


### PR DESCRIPTION
This adds an option in the projects module config that will allow archived projects to either be enabled or disabled in the 'all' tab when viewing projects which helps reduce clutter when looking for projects