### PR TITLE
Getting error above php 5.6

### DIFF
--- a/classes/authenticator.class.php
+++ b/classes/authenticator.class.php
@@ -188,7 +188,7 @@ if (!defined('DP_BASE_DIR')) {
 			return false;
 		}
 
-		function userId()
+		function userId($username)
 		{
 			return $this->user_id;
 		}


### PR DESCRIPTION
Warning: Declaration of LDAPAuthenticator::userId($username) should be compatible with SQLAuthenticator::userId() in classes/authenticator.class.php on line 362

this change works above php 5.6