### PR TITLE
Allowing browser to view files instead of always downloading.. -  fileviewer.php

### DIFF
--- a/fileviewer.php
+++ b/fileviewer.php
@@ -163,7 +163,7 @@ if ($file_id) {
 	header('Content-length: '.$file['file_size']);
 	header('Content-type: '.$file['file_type']);
 	header('Content-transfer-encoding: 8bit');
-	header('Content-disposition: attachment; filename="'.$file['file_name'].'"');
+	header('Content-disposition: inline; filename="'.$file['file_name'].'"');
 
 	// read and output the file in chunks to bypass limiting settings in php.ini
 	$handle = fopen(DP_BASE_DIR . '/files/'.$file['file_project'].'/'.$file['file_real_filename'], 'rb');


### PR DESCRIPTION
Changed "Content-disposition" header from "attachment" to "inline" to allow the file to be opened by the browser directly instead of downloading every time.